### PR TITLE
Update amend.cpp

### DIFF
--- a/contracts/amend/src/amend.cpp
+++ b/contracts/amend/src/amend.cpp
@@ -156,9 +156,6 @@ ACTION amend::newdocument(string title, string subtitle, name document_name, nam
         //validate
         check(sec_itr == sections.end(), "section already exists");
 
-        //iterate
-        sec_order += 1;
-
         //emplace new section
         sections.emplace(author, [&](auto& col) {
             col.section_name = itr->first;
@@ -166,6 +163,9 @@ ACTION amend::newdocument(string title, string subtitle, name document_name, nam
             col.content = itr->second;
             col.last_amended = now;
             col.amended_by = author;
+            
+        //iterate
+        sec_order += 1;
         });
 
     }


### PR DESCRIPTION
When initializing new documents, emplace the document section before incrementing to a new section number. Otherwise the first section will be 1 instead of 0 and the first new section to be added through a later Amend vote will be section 0, creating an ordering problem.